### PR TITLE
Fix broken arrows in element tab

### DIFF
--- a/themes/chrome-dev-tools/less/_panel-elements.less
+++ b/themes/chrome-dev-tools/less/_panel-elements.less
@@ -14,7 +14,6 @@
 //  Element Highlighter
 // ==========================================================================
 .elements-disclosure {
-	.arrow-mixin();
 
 	ol:focus li.selected .selection,
 	li.selected .selection {


### PR DESCRIPTION
Seems like the arrow mixin is breaking the arrows in elements tab 😢 

This PR removes the broken mixin and the arrows are happy again 😃 

![image](https://github.com/ntwigs/magoon/assets/14079937/d0238005-2430-4f10-a37a-9653b113cc62)

🙏 